### PR TITLE
Add option to apply mark on every pages of the document

### DIFF
--- a/pdfwatermark.py
+++ b/pdfwatermark.py
@@ -30,8 +30,12 @@ import click
               help='Y coordinate')
 @click.option('-d', '--destination-file-name', default='',
               help='Destination file, by default files are modified in place')
+@click.option('-a', '--all-pages', default=False, is_flag=True, type=bool,
+              help='Apply the mark on every pages of the document')
+
+
 def annotate(filename, watermark, regex, font_name, font_size, color, opacity,
-             x, y, destination_file_name):
+             x, y, destination_file_name, all_pages):
     mask_stream = BytesIO()
 
     watermark_canvas = canvas.Canvas(mask_stream, pagesize=A4)
@@ -53,12 +57,11 @@ def annotate(filename, watermark, regex, font_name, font_size, color, opacity,
     src = PdfFileReader(filename)
     output = PdfFileWriter()
 
-    page = src.getPage(0)
-    page.mergePage(mask.getPage(0))
-    output.addPage(page)
-
-    for page in range(1, src.getNumPages()):
-        output.addPage(src.getPage(page))
+    for page_index in range(0, src.getNumPages()):
+        page = src.getPage(page_index)
+        if page_index == 0 or all_pages:
+            page.mergePage(mask.getPage(0))
+        output.addPage(page)
 
     if not destination_file_name:
         destination_file_name = filename


### PR DESCRIPTION
As it could be useful to apply the mark on all pages of a document, I added an option `-a` (or `--all-pages`) to do so.
The default behavior remains to only mark the first page.